### PR TITLE
Fixed black screen on tool switch

### DIFF
--- a/src/rendering/d3d12.cpp
+++ b/src/rendering/d3d12.cpp
@@ -326,6 +326,7 @@ void RND_D3D12::PresentPipeline<depth>::UpdateSettingsBuffer(ID3D12Resource* swa
         .customFadeColorG = 0.0f,
         .customFadeColorB = 0.0f,
         .isFadeActive = 0.0f,
+        .hudMaxAlpha = 1.0f,
     };
 
     if constexpr (depth) {
@@ -335,6 +336,9 @@ void RND_D3D12::PresentPipeline<depth>::UpdateSettingsBuffer(ID3D12Resource* swa
         settings.customFadeColorG = fade.color.y;
         settings.customFadeColorB = fade.color.z;
         settings.isFadeActive = m_renderer != nullptr && m_renderer->IsFadeActive() ? 1.0f : 0.0f;
+    }
+    else {
+        settings.hudMaxAlpha = m_renderer != nullptr ? m_renderer->GetHudMaxAlpha() : 1.0f;
     }
 
     void* data = nullptr;

--- a/src/rendering/renderer.cpp
+++ b/src/rendering/renderer.cpp
@@ -56,7 +56,8 @@ bool RND_Renderer::IsStable3DReuseAllowed(const RenderFrame& frame) const {
         return false;
     }
     const bool isMonoFallbackFrame = (frame.issueFlags & CaptureIssue_MonoCapture) != 0;
-    if (!isMonoFallbackFrame && !CemuHooks::IsInGame()) {
+    const bool isDpadMenuOpen = VRManager::instance().XR->m_gameState.load().dpad_menu_open_requested;
+    if (!isMonoFallbackFrame && !CemuHooks::IsInGame() && !isDpadMenuOpen) {
         return false;
     }
     if (CemuHooks::UseBlackBarsDuringEvents()) {
@@ -286,6 +287,12 @@ void RND_Renderer::EndFrame() {
     m_isFadeActive.store(isFadeVisible, std::memory_order_relaxed);
     SetCustomFadeColor(glm::fvec3(0.0f));
     SetCustomFadeAmount(std::max(roomscaleFade, snapTurnFade));
+
+    // the dpad quick-menu's darkening backdrop is baked into the HUD capture as opaque black
+    // (correct in flatscreen where it draws into the same buffer as the 3D scene, but it would
+    // fully occlude our separately-composited HUD layer), so cap its alpha instead of letting it through
+    const bool isDpadMenuOpenForHud = VRManager::instance().XR->m_gameState.load().dpad_menu_open_requested;
+    SetHudMaxAlpha(isDpadMenuOpenForHud ? 0.55f : 1.0f);
 
     bool reusedStable3D = false;
     long presented3DFrameIdx = -1;

--- a/src/rendering/renderer.h
+++ b/src/rendering/renderer.h
@@ -385,6 +385,12 @@ public:
 
     bool IsFadeActive() const { return m_isFadeActive.load(std::memory_order_relaxed); }
 
+    void SetHudMaxAlpha(float maxAlpha) {
+        m_hudMaxAlpha.store(glm::clamp(maxAlpha, 0.0f, 1.0f), std::memory_order_relaxed);
+    }
+
+    float GetHudMaxAlpha() const { return m_hudMaxAlpha.load(std::memory_order_relaxed); }
+
 private:
     bool IsCurrent3DPresentationAllowed(const RenderFrame& frame) const;
     bool IsStable3DReuseAllowed(const RenderFrame& frame) const;
@@ -423,6 +429,7 @@ protected:
     std::atomic<float> m_customFadeColorR = 0.0f;
     std::atomic<float> m_customFadeColorG = 0.0f;
     std::atomic<float> m_customFadeColorB = 0.0f;
+    std::atomic<float> m_hudMaxAlpha = 1.0f;
 
     // Full-frame timing derived from OpenXR timestamps (XrTime is in nanoseconds)
     XrTime m_lastPredictedDisplayTime = 0;

--- a/src/shader.h
+++ b/src/shader.h
@@ -28,6 +28,7 @@ cbuffer g_settings : register(b1) {
     float customFadeColorG;
     float customFadeColorB;
     float isFadeActive;
+    float hudMaxAlpha;
 };
 
 Texture2D g_colorTexture : register(t0);
@@ -101,6 +102,7 @@ cbuffer g_settings : register(b1) {
     float customFadeColorG;
     float customFadeColorB;
     float isFadeActive;
+    float hudMaxAlpha;
 };
 
 Texture2D g_colorTexture : register(t0);
@@ -121,9 +123,12 @@ PSOutput PSMain(PSInput input) {
 
     float4 colorTexture = g_colorTexture.Sample(g_sampler, samplePosition);
 
+    // the dpad quick-menu's darkening backdrop is baked into the HUD capture as opaque black
+    // (correct in flatscreen where it draws into the same buffer as the 3D scene, but it would
+    // fully occlude our separately-composited HUD layer), so cap its alpha instead of letting it through
     PSOutput output;
 	//output.Color = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    output.Color = float4(colorTexture.x, colorTexture.y, colorTexture.z, colorTexture.w);
+    output.Color = float4(colorTexture.x, colorTexture.y, colorTexture.z, min(colorTexture.w, hudMaxAlpha));
     return output;
 }
 )hlsl";
@@ -194,6 +199,7 @@ struct presentSettings {
     float customFadeColorG;
     float customFadeColorB;
     float isFadeActive;
+    float hudMaxAlpha;
 };
 
 struct debugDrawLineSettings {


### PR DESCRIPTION
Fixed a screen bug that resulted in the screen turning black when switching tools. Still not 100% perfect since it leaves a semi transparent box and makes the icons slightly dimmer but this solution seems better than the whole screen turning black. 